### PR TITLE
feat: update to node 20

### DIFF
--- a/.github/workflows/wf-auto-pr-check.yml
+++ b/.github/workflows/wf-auto-pr-check.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       NODE_VERSION:
         description: "The version of Node to use when building the site."
-        default: "16"
+        default: "20"
         required: false
         type: string
       NPM_INSTALL_COMMAND:
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare Repository
         # Fetch full git history and tags
         run: git fetch --unshallow --tags
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         env:
           ARTIFACTORY_TOKEN: "${{ secrets.NPM_TOKEN }}"
           ARTIFACTORY_USERNAME: "${{ secrets.ARTIFACTORY_USERNAME }}"

--- a/.github/workflows/wf-build-and-test.yml
+++ b/.github/workflows/wf-build-and-test.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       NODE_VERSION:
         description: "The version of Node to use when building the site."
-        default: "16"
+        default: "20"
         required: false
         type: string
       BUILD_ENABLED:
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         env:
           NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
           ARTIFACTORY_TOKEN: "${{ secrets.NPM_TOKEN }}"

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       NODE_VERSION:
         description: "The version of Node to use when building the site."
-        default: "16"
+        default: "20"
         required: false
         type: string
       PRODUCTION_RELEASE:
@@ -104,21 +104,21 @@ jobs:
       - name: Set GitHub App Token
         id: app-token
         if: ${{ inputs.PRODUCTION_RELEASE }}
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2.1
         with:
           app_id: ${{ secrets.GITHUB_APP_ID }}
           private_key: ${{ secrets.GITHUB_APP_KEY }}
 
       - name: Checkout Repo with App
         id: checkout-with-token
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.app-token.outcome == 'success'
         with:
           # Checkout with github apps token.
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.checkout-with-token.outcome == 'skipped'
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
         run: git fetch --unshallow --tags
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         env:
           NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
           ARTIFACTORY_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -242,7 +242,7 @@ jobs:
           npm run "${PACKAGE_ASSETS_NPM_SCRIPT}"
 
       - name: Upload assets for deploy
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.package-assets.outcome == 'success'
         with:
           name: ${{ inputs.PACKAGE_ASSETS_UPLOAD_NAME }}

--- a/.github/workflows/wf-cleanup-gh-pages.yml
+++ b/.github/workflows/wf-cleanup-gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           token: ${{ secrets.GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/wf-configuration.yml
+++ b/.github/workflows/wf-configuration.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       NODE_VERSION:
         description: "The version of Node to use when building the site."
-        default: "16"
+        default: 20"
         required: false
         type: string
       FILE_FILTERS:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare Repository
         # Fetch full git history and tags
@@ -38,7 +38,7 @@ jobs:
 
       - name: Cache Dependencies
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -50,7 +50,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         env:
           NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
           ARTIFACTORY_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -90,7 +90,7 @@ jobs:
       ## Detect if any specific files we care about have changed to help us know if we need to
       ## execute a CI build or Storybook deployment at all or not
       - name: Check File Changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: file-filter
         with:
           filters: ${{ inputs.FILE_FILTERS }}

--- a/.github/workflows/wf-publish-cloudfront-assets.yml
+++ b/.github/workflows/wf-publish-cloudfront-assets.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Download Assets from Build Job
         id: download-assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.ARTIFACT_NAME }}
           path: ${{ inputs.ARTIFACT_NAME }}
@@ -64,7 +64,7 @@ jobs:
       # ---------------------------------------------------------------------------- #
       - name: Configure AWS Credentials
         id: configure-credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/wf-publish-gh-pages.yml
+++ b/.github/workflows/wf-publish-gh-pages.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       NODE_VERSION:
         description: "The version of Node to use when building the site."
-        default: "16"
+        default: "20"
         required: false
         type: string
       DEPLOY_BRANCH:
@@ -71,14 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       
       - name: Cache Dependencies
         id: cache
         if: ${{ inputs.CACHE_ENABLED }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -90,7 +90,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         env:
           NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
           ARTIFACTORY_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -133,7 +133,7 @@ jobs:
 
       - name: Deploy 🚀
         if: ${{ inputs.BUILD_ENABLED }}
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           token: ${{ secrets.GITHUB_DEPLOY_TOKEN }}
           branch: ${{ inputs.DEPLOY_BRANCH }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Find Comment
         if: ${{ inputs.BUILD_ENABLED && ! inputs.PRODUCTION_RELEASE }}
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Create comment
         if: ${{ inputs.BUILD_ENABLED && ! inputs.PRODUCTION_RELEASE && steps.fc.outputs.comment-id == '' }}
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |


### PR DESCRIPTION
Update default `NODE_VERSION` to 20, and update action versions to v20-compatible versions where possible.

The following dependencies do not yet support Node 20:
- reggionick/s3-deploy#193 merged just yesterday, but has not been released yet
- [numtide/clean-git-action](https://github.com/numtide/clean-git-action) does not appear to be well-maintained, and is really just executing a [very simple bash script](https://github.com/numtide/clean-git-action/blob/main/post.sh).  We should probably internalize the command instead of using the repository.

Closes #3 